### PR TITLE
Add Missing PrometheusRule for Burn Rate (4d)

### DIFF
--- a/internal/controller/servicelevelobjective_controller.go
+++ b/internal/controller/servicelevelobjective_controller.go
@@ -367,6 +367,7 @@ func generatePrometheusRuleGroup(slo ricobergerdev1alpha1.SLO, labels map[string
 		generatePrometheusRuleBurnRateRecording(slo.SLI, sloLabels, "2h"),
 		generatePrometheusRuleBurnRateRecording(slo.SLI, sloLabels, "6h"),
 		generatePrometheusRuleBurnRateRecording(slo.SLI, sloLabels, "1d"),
+		generatePrometheusRuleBurnRateRecording(slo.SLI, sloLabels, "4d"),
 	}
 
 	// If the alerting isn't disabled by the user, we add the alerting rules


### PR DESCRIPTION
The burn rate for 4 days which is used in the alerts, wasn't created as
a recording rule. This is now fixed.
