### PR TITLE
Add Tests for ServiceLevelObjective Controller

### DIFF
--- a/internal/controller/servicelevelobjective_controller_test.go
+++ b/internal/controller/servicelevelobjective_controller_test.go
@@ -5,23 +5,26 @@ import (
 
 	ricobergerdev1alpha1 "github.com/ricoberger/slo-operator/api/v1alpha1"
 
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("ServiceLevelObjective Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
-
+		format.MaxLength = 10000000
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Name:      "test",
+			Namespace: "default",
 		}
 		servicelevelobjective := &ricobergerdev1alpha1.ServiceLevelObjective{}
 
@@ -31,17 +34,30 @@ var _ = Describe("ServiceLevelObjective Controller", func() {
 			if err != nil && errors.IsNotFound(err) {
 				resource := &ricobergerdev1alpha1.ServiceLevelObjective{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
+						Name:      "test",
 						Namespace: "default",
+						Labels: map[string]string{
+							"slo-operator.ricoberger.de/team": "myteam",
+						},
 					},
-					// TODO(user): Specify other spec details if needed.
+					Spec: ricobergerdev1alpha1.ServiceLevelObjectiveSpec{
+						SLOs: []ricobergerdev1alpha1.SLO{
+							{
+								Name:      "availability",
+								Objective: "90",
+								SLI: ricobergerdev1alpha1.SLI{
+									TotalQuery: `sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[${window}]))`,
+									ErrorQuery: `sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[${window}]))`,
+								},
+							},
+						},
+					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &ricobergerdev1alpha1.ServiceLevelObjective{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -50,7 +66,7 @@ var _ = Describe("ServiceLevelObjective Controller", func() {
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
 
-		It("Should successfully reconcile the resource", func() {
+		It("Should successfully reconcile the resource (PrometheusRule)", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &ServiceLevelObjectiveReconciler{
 				Client: k8sClient,
@@ -61,8 +77,471 @@ var _ = Describe("ServiceLevelObjective Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			By("Check if PrometheusRule was created")
+			prometheusRule := &monitoringv1.PrometheusRule{}
+			err = k8sClient.Get(ctx, typeNamespacedName, prometheusRule)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prometheusRule.Spec).To(Equal(monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{
+					{
+						Name:     "slo-generic-test-default-availability",
+						Interval: monitoringv1.DurationPointer("30s"),
+						Rules: []monitoringv1.Rule{
+							{
+								Record: "slo:window",
+								Expr:   intstr.FromInt(2419200),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:objective",
+								Expr:   intstr.FromString("0.9"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:total",
+								Expr:   intstr.FromString(`sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2m]))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:errors_total",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[2m]))) or vector(0)`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:availability",
+								Expr:   intstr.FromString(`1 - ((sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[28d]))) or vector(0)) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[28d])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Alert: "SLOMetricAbsent",
+								Expr:  intstr.FromString(`absent(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2m]))) == 1`),
+								For:   monitoringv1.DurationPointer("10m"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "critical",
+								},
+							},
+						},
+					},
+					{
+						Name:     "slo-errors-test-default-availability",
+						Interval: monitoringv1.DurationPointer("30s"),
+						Rules: []monitoringv1.Rule{
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[5m]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[5m])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "5m",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[30m]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[30m])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "30m",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[1h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[1h])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "1h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[2h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2h])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "2h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[6h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[6h])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "6h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[1d]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[1d])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "1d",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   intstr.FromString(`(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[4d]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[4d])))`),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "4d",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  intstr.FromString(`slo:burnrate{window="5m", id="test-default-availability"} > (14 * (1-0.9)) and slo:burnrate{window="1h", id="test-default-availability"} > (14 * (1-0.9))`),
+								For:   monitoringv1.DurationPointer("2m"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "error",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  intstr.FromString(`slo:burnrate{window="30m", id="test-default-availability"} > (7 * (1-0.9)) and slo:burnrate{window="6h", id="test-default-availability"} > (7 * (1-0.9))`),
+								For:   monitoringv1.DurationPointer("15m"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "error",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  intstr.FromString(`slo:burnrate{window="2h", id="test-default-availability"} > (2 * (1-0.9)) and slo:burnrate{window="1d", id="test-default-availability"} > (2 * (1-0.9))`),
+								For:   monitoringv1.DurationPointer("1h"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "warning",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  intstr.FromString(`slo:burnrate{window="6h", id="test-default-availability"} > (1 * (1-0.9)) and slo:burnrate{window="4d", id="test-default-availability"} > (1 * (1-0.9))`),
+								For:   monitoringv1.DurationPointer("3h"),
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "warning",
+								},
+							},
+						},
+					},
+				},
+			}))
+		})
+
+		It("Should successfully reconcile the resource (VMRule)", func() {
+			sloOperatorMode = "victoriametrics"
+
+			By("Reconciling the created resource")
+			controllerReconciler := &ServiceLevelObjectiveReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check if VMRule was created")
+			vmRule := &vmv1beta1.VMRule{}
+			err = k8sClient.Get(ctx, typeNamespacedName, vmRule)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmRule.Spec).To(Equal(vmv1beta1.VMRuleSpec{
+				Groups: []vmv1beta1.RuleGroup{
+					{
+						Name:     "slo-generic-test-default-availability",
+						Interval: "30s",
+						Rules: []vmv1beta1.Rule{
+							{
+								Record: "slo:window",
+								Expr:   "2419200",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:objective",
+								Expr:   "0.9",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:total",
+								Expr:   `sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2m]))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:errors_total",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[2m]))) or vector(0)`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Record: "slo:availability",
+								Expr:   `1 - ((sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[28d]))) or vector(0)) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[28d])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+								},
+							},
+							{
+								Alert: "SLOMetricAbsent",
+								Expr:  `absent(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2m]))) == 1`,
+								For:   "10m",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "critical",
+								},
+							},
+						},
+					},
+					{
+						Name:     "slo-errors-test-default-availability",
+						Interval: "30s",
+						Rules: []vmv1beta1.Rule{
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[5m]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[5m])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "5m",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[30m]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[30m])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "30m",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[1h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[1h])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "1h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[2h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[2h])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "2h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[6h]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[6h])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "6h",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[1d]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[1d])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "1d",
+								},
+							},
+							{
+								Record: "slo:burnrate",
+								Expr:   `(sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana",response_code=~"5.*"}[4d]))) / (sum(rate(istio_requests_total{destination_workload_namespace=~"monitoring",destination_workload=~"grafana"}[4d])))`,
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"window":    "4d",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  `slo:burnrate{window="5m", id="test-default-availability"} > (14 * (1-0.9)) and slo:burnrate{window="1h", id="test-default-availability"} > (14 * (1-0.9))`,
+								For:   "2m",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "error",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  `slo:burnrate{window="30m", id="test-default-availability"} > (7 * (1-0.9)) and slo:burnrate{window="6h", id="test-default-availability"} > (7 * (1-0.9))`,
+								For:   "15m",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "error",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  `slo:burnrate{window="2h", id="test-default-availability"} > (2 * (1-0.9)) and slo:burnrate{window="1d", id="test-default-availability"} > (2 * (1-0.9))`,
+								For:   "1h",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "warning",
+								},
+							},
+							{
+								Alert: "SLOErrorBudgetBurn",
+								Expr:  `slo:burnrate{window="6h", id="test-default-availability"} > (1 * (1-0.9)) and slo:burnrate{window="4d", id="test-default-availability"} > (1 * (1-0.9))`,
+								For:   "3h",
+								Labels: map[string]string{
+									"namespace": "default",
+									"name":      "test",
+									"team":      "myteam",
+									"id":        "test-default-availability",
+									"slo":       "availability",
+									"severity":  "warning",
+								},
+							},
+						},
+					},
+				},
+			}))
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -9,8 +9,10 @@ import (
 	ricobergerdev1alpha1 "github.com/ricoberger/slo-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +41,10 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	var err error
+	err = monitoringv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = vmv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 	err = ricobergerdev1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -46,7 +52,10 @@ var _ = BeforeSuite(func() {
 
 	By("Bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "charts", "slo-operator", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "charts", "slo-operator", "crds"),
+			filepath.Join("..", "..", "tests", "crds"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 

--- a/tests/crds/monitoring.coreos.com_prometheusrules.yaml
+++ b/tests/crds/monitoring.coreos.com_prometheusrules.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    operator.prometheus.io/version: 0.83.0
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+      - prometheus-operator
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    shortNames:
+      - promrule
+    singular: prometheusrule
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            The `PrometheusRule` custom resource definition (CRD) defines [alerting](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) and [recording](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) rules to be evaluated by `Prometheus` or `ThanosRuler` objects.
+
+            `Prometheus` and `ThanosRuler` objects select `PrometheusRule` objects using label and namespace selectors.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                Specification of desired alerting rule definitions for
+                Prometheus.
+              properties:
+                groups:
+                  description: Content of Prometheus rule file
+                  items:
+                    description:
+                      RuleGroup is a list of sequentially evaluated recording
+                      and alerting rules.
+                    properties:
+                      interval:
+                        description:
+                          Interval determines how often rules in the group are
+                          evaluated.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels to add or overwrite before storing the result for its rules.
+                          The labels defined at the rule level take precedence.
+
+                          It requires Prometheus >= 3.0.0.
+                          The field is ignored for Thanos Ruler.
+                        type: object
+                      limit:
+                        description: |-
+                          Limit the number of alerts an alerting rule and series a recording
+                          rule can produce.
+                          Limit is supported starting with Prometheus >= 2.31 and Thanos Ruler >= 0.24.
+                        type: integer
+                      name:
+                        description: Name of the rule group.
+                        minLength: 1
+                        type: string
+                      partial_response_strategy:
+                        description: |-
+                          PartialResponseStrategy is only used by ThanosRuler and will
+                          be ignored by Prometheus instances.
+                          More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response
+                        pattern: ^(?i)(abort|warn)?$
+                        type: string
+                      query_offset:
+                        description: |-
+                          Defines the offset the rule evaluation timestamp of this particular group by the specified duration into the past.
+
+                          It requires Prometheus >= v2.53.0.
+                          It is not supported for ThanosRuler.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      rules:
+                        description: List of alerting and recording rules.
+                        items:
+                          description: |-
+                            Rule describes an alerting or recording rule
+                            See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) rule
+                          properties:
+                            alert:
+                              description: |-
+                                Name of the alert. Must be a valid label value.
+                                Only one of `record` and `alert` must be set.
+                              type: string
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations to add to each alert.
+                                Only valid for alerting rules.
+                              type: object
+                            expr:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: PromQL expression to evaluate.
+                              x-kubernetes-int-or-string: true
+                            for:
+                              description:
+                                Alerts are considered firing once they have been
+                                returned for this long.
+                              pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                              type: string
+                            keep_firing_for:
+                              description:
+                                KeepFiringFor defines how long an alert will
+                                continue firing after the condition that
+                                triggered it has cleared.
+                              minLength: 1
+                              pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                              type: string
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels to add or overwrite.
+                              type: object
+                            record:
+                              description: |-
+                                Name of the time series to output to. Must be a valid metric name.
+                                Only one of `record` and `alert` must be set.
+                              type: string
+                          required:
+                            - expr
+                          type: object
+                        type: array
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/tests/crds/operator.victoriametrics.com_vmrules.yaml
+++ b/tests/crds/operator.victoriametrics.com_vmrules.yaml
@@ -1,0 +1,304 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: vmrules.operator.victoriametrics.com
+spec:
+  group: operator.victoriametrics.com
+  names:
+    kind: VMRule
+    listKind: VMRuleList
+    plural: vmrules
+    singular: vmrule
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.updateStatus
+          name: Status
+          type: string
+        - jsonPath: .status.reason
+          name: Sync Error
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VMRule defines rule records for vmalert application
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VMRuleSpec defines the desired state of VMRule
+              properties:
+                groups:
+                  description: Groups list of group rules
+                  items:
+                    description:
+                      RuleGroup is a list of sequentially evaluated recording
+                      and alerting rules.
+                    properties:
+                      concurrency:
+                        description:
+                          Concurrency defines how many rules execute at once.
+                        type: integer
+                      eval_alignment:
+                        description: |-
+                          Optional
+                          The evaluation timestamp will be aligned with group's interval,
+                          instead of using the actual timestamp that evaluation happens at.
+                          It is enabled by default to get more predictable results
+                          and to visually align with graphs plotted via Grafana or vmui.
+                        type: boolean
+                      eval_delay:
+                        description: |-
+                          Optional
+                          Adjust the `time` parameter of group evaluation requests to compensate intentional query delay from the datasource.
+                        type: string
+                      eval_offset:
+                        description: |-
+                          Optional
+                          Group will be evaluated at the exact offset in the range of [0...interval].
+                        type: string
+                      extra_filter_labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ExtraFilterLabels optional list of label filters applied to every rule's
+                          request within a group. Is compatible only with VM datasource.
+                          See more details [here](https://docs.victoriametrics.com/#prometheus-querying-api-enhancements)
+                          Deprecated: use params instead
+                        type: object
+                      headers:
+                        description: |-
+                          Headers contains optional HTTP headers added to each rule request
+                          Must be in form `header-name: value`
+                          For example:
+                           headers:
+                             - "CustomHeader: foo"
+                             - "CustomHeader2: bar"
+                        items:
+                          type: string
+                        type: array
+                      interval:
+                        description: evaluation interval for group
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels optional list of labels added to every rule within a group.
+                          It has priority over the external labels.
+                          Labels are commonly used for adding environment
+                          or tenant-specific tag.
+                        type: object
+                      limit:
+                        description: |-
+                          Limit the number of alerts an alerting rule and series a recording
+                          rule can produce
+                        type: integer
+                      name:
+                        description: Name of group
+                        type: string
+                      notifier_headers:
+                        description: |-
+                          NotifierHeaders contains optional HTTP headers added to each alert request which will send to notifier
+                          Must be in form `header-name: value`
+                          For example:
+                           headers:
+                             - "CustomHeader: foo"
+                             - "CustomHeader2: bar"
+                        items:
+                          type: string
+                        type: array
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          Params optional HTTP URL parameters added to each rule
+                          request
+                        type: object
+                      rules:
+                        description: Rules list of alert rules
+                        items:
+                          description:
+                            Rule describes an alerting or recording rule.
+                          properties:
+                            alert:
+                              description: Alert is a name for alert
+                              type: string
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description:
+                                Annotations will be added to rule configuration
+                              type: object
+                            debug:
+                              description: |-
+                                Debug enables logging for rule
+                                it useful for tracking
+                              type: boolean
+                            expr:
+                              description:
+                                Expr is query, that will be evaluated at
+                                dataSource
+                              type: string
+                            for:
+                              description: |-
+                                For evaluation interval in time.Duration format
+                                30s, 1m, 1h  or nanoseconds
+                              type: string
+                            keep_firing_for:
+                              description: |-
+                                KeepFiringFor will make alert continue firing for this long
+                                even when the alerting expression no longer has results.
+                                Use time.Duration format, 30s, 1m, 1h  or nanoseconds
+                              type: string
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description:
+                                Labels will be added to rule configuration
+                              type: object
+                            record:
+                              description:
+                                Record represents a query, that will be recorded
+                                to dataSource
+                              type: string
+                            update_entries_limit:
+                              description: |-
+                                UpdateEntriesLimit defines max number of rule's state updates stored in memory.
+                                Overrides `-rule.updateEntriesLimit` in vmalert.
+                              type: integer
+                          type: object
+                        type: array
+                      tenant:
+                        description: |-
+                          Tenant id for group, can be used only with enterprise version of vmalert.
+                          See more details [here](https://docs.victoriametrics.com/vmalert#multitenancy).
+                        type: string
+                      type:
+                        description: |-
+                          Type defines datasource type for enterprise version of vmalert
+                          possible values - prometheus,graphite,vlogs
+                        type: string
+                    required:
+                      - name
+                      - rules
+                    type: object
+                  type: array
+              required:
+                - groups
+              type: object
+            status:
+              description: VMRuleStatus defines the observed state of VMRule
+              properties:
+                conditions:
+                  description:
+                    'Known .status.conditions.type are: "Available",
+                    "Progressing", and "Degraded"'
+                  items:
+                    description:
+                      Condition defines status condition of the resource
+                    properties:
+                      lastTransitionTime:
+                        description:
+                          lastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: |-
+                          LastUpdateTime is the last time of given type update.
+                          This value is used for status TTL update and removal
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                      status:
+                        description:
+                          status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description:
+                          Type of condition in CamelCase or in
+                          name.namespace.resource.victoriametrics.com/CamelCase.
+                        maxLength: 316
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - lastUpdateTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration defines current generation picked by operator for the
+                    reconcile
+                  format: int64
+                  type: integer
+                reason:
+                  description: Reason defines human readable error reason
+                  type: string
+                updateStatus:
+                  description: UpdateStatus defines a status for update rollout
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
Add some tests for the ServiceLevelObjective controller. The added tests
cover, that the controller can reconcile a ServiceLevelObjective and
creates a PrometheusRule or VMRule depending on the mode the operator
uses.
