### PR TITLE
Improve ServiceLevelObjective Dashboard

### DIFF
--- a/assets/dashboards/servicelevelobjective.json
+++ b/assets/dashboards/servicelevelobjective.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 243,
+  "id": 262,
   "links": [],
   "panels": [
     {
@@ -411,7 +411,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 1,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -512,7 +511,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 1,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -620,7 +618,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMin": 0,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -662,7 +659,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -721,8 +718,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 1,
-            "axisSoftMin": 0,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -765,7 +760,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "ops"
         },
         "overrides": [
           {
@@ -923,5 +918,5 @@
   "timezone": "",
   "title": "Service Level Objective",
   "uid": "servicelevelobjective",
-  "version": 11
+  "version": 2
 }


### PR DESCRIPTION
Improve the ServiceLevelObjective dashboard, by:

- removing the min and max soft values from the graphs
- chaning the unit in the rate and errors graph from rps to ops
