### PR TITLE
Add Permissions for Leader Election to ClusterRole

### DIFF
--- a/charts/slo-operator/Chart.yaml
+++ b/charts/slo-operator/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: slo-operator
 description: Generate Prometheus SLOs
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.2.0

--- a/charts/slo-operator/templates/clusterrole.yaml
+++ b/charts/slo-operator/templates/clusterrole.yaml
@@ -6,54 +6,73 @@ metadata:
   labels:
     {{- include "slo-operator.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheusrules
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - operator.victoriametrics.com
-  resources:
-  - vmrules
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ricoberger.de
-  resources:
-  - servicelevelobjectives
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ricoberger.de
-  resources:
-  - servicelevelobjectives/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ricoberger.de
-  resources:
-  - servicelevelobjectives/status
-  verbs:
-  - get
-  - patch
-  - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ricoberger.de
+    resources:
+      - servicelevelobjectives
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ricoberger.de
+    resources:
+      - servicelevelobjectives/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ricoberger.de
+    resources:
+      - servicelevelobjectives/status
+    verbs:
+      - get
+      - patch
+      - update
 {{ end }}

--- a/internal/controller/servicelevelobjective_controller.go
+++ b/internal/controller/servicelevelobjective_controller.go
@@ -37,6 +37,8 @@ type ServiceLevelObjectiveReconciler struct {
 // +kubebuilder:rbac:groups=ricoberger.de,resources=servicelevelobjectives/finalizers,verbs=update
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Add the required permissions for the leader election to the ClusterRole,
by running the `make generate` and `make manifests` command.
